### PR TITLE
Update eval loss in modern.py.

### DIFF
--- a/modern.py
+++ b/modern.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         model.eval()
         X, Y = (Xtr, Ytr) if split == 'train' else (Xte, Yte)
         Yhat = model(X)
-        loss = F.cross_entropy(yhat, y.argmax(dim=1))
+        loss = F.cross_entropy(Yhat, Y.argmax(dim=1))
         err = torch.mean((Y.argmax(dim=1) != Yhat.argmax(dim=1)).float())
         print(f"eval: split {split:5s}. loss {loss.item():e}. error {err.item()*100:.2f}%. misses: {int(err.item()*Y.size(0))}")
         writer.add_scalar(f'error/{split}', err.item()*100, pass_num)


### PR DESCRIPTION
I would like to update the loss numbers in the comment section too, but I could not reproduce your numbers.

For repro.py, I am getting
23
eval: split train. loss 5.344314e-03. error 0.86%. misses: 63
eval: split test . loss 2.703927e-02. error 3.54%. misses: 71

And for modern.py, I am getting
80
eval: split train. loss 4.209032e-02. error 1.11%. misses: 80
eval: split test . loss 5.929652e-02. error 1.99%. misses: 39

Not clear if this is due to different data subsets or library behavior. I am using `numpy==1.20.3`, `torch==1.11.0` and `torchvision==0.12.0`.