### PR TITLE
Fix eval cross_entropy loss calculation

### DIFF
--- a/modern.py
+++ b/modern.py
@@ -171,7 +171,7 @@ if __name__ == '__main__':
         model.eval()
         X, Y = (Xtr, Ytr) if split == 'train' else (Xte, Yte)
         Yhat = model(X)
-        loss = F.cross_entropy(yhat, y.argmax(dim=1))
+        loss = F.cross_entropy(Yhat, Y.argmax(dim=1))
         err = torch.mean((Y.argmax(dim=1) != Yhat.argmax(dim=1)).float())
         print(f"eval: split {split:5s}. loss {loss.item():e}. error {err.item()*100:.2f}%. misses: {int(err.item()*Y.size(0))}")
         writer.add_scalar(f'error/{split}', err.item()*100, pass_num)


### PR DESCRIPTION
- It now uses the proper Y and Yhat to calculate loss.

Maybe we shouldn't merge it in, cause the benchmarks will be wrong. I guess having this PR is just good documentation in general.